### PR TITLE
users first and last name no longer required to exist in DB

### DIFF
--- a/db/migrate/20130617232345_add_data_to_users.rb
+++ b/db/migrate/20130617232345_add_data_to_users.rb
@@ -1,8 +1,8 @@
 class AddDataToUsers < ActiveRecord::Migration
   def change
     change_table :users do |t|
-      t.string :first_name, null: false, default: ""
-      t.string :last_name,  null: false, default: ""
+      t.string :first_name
+      t.string :last_name
       t.date :birth_date
       t.text :bio
       t.string :facebook_link

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,18 +59,20 @@ ActiveRecord::Schema.define(:version => 20130702113353) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at",                              :null => false
     t.datetime "updated_at",                              :null => false
-    t.string   "first_name",           :default => "",    :null => false
-    t.string   "last_name",            :default => "",    :null => false
-    t.string   "facebook_link",        :default => "",    :null => false
+    t.string   "first_name"
+    t.string   "last_name"
     t.date     "birth_date"
+    t.text     "bio"
+    t.string   "facebook_link"
+    t.string   "twitter_handle"
     t.string   "picture_file_name"
     t.string   "picture_content_type"
     t.integer  "picture_file_size"
     t.datetime "picture_updated_at"
-    t.boolean  "profile_finished",     :default => false
     t.integer  "country_id"
     t.integer  "university_id"
     t.datetime "deleted_at"
+    t.boolean  "profile_finished",     :default => false
   end
 
   add_index "users", ["country_id"], :name => "index_users_on_country_id"

--- a/spec/profiles/services/oauth_authenticator_spec.rb
+++ b/spec/profiles/services/oauth_authenticator_spec.rb
@@ -5,10 +5,9 @@ describe Services::OauthAuthenticator do
   context "#authenticate!" do
     it "authenticates an existing facebook user" do
       facebook_data = OmniAuth.config.mock_auth[:facebook]
-      user = build :user
-      authorization = build :facebook_authorization, uid: facebook_data[:uid], user: user
+      user = create :user
+      authorization = create :facebook_authorization, uid: facebook_data[:uid], user: user
       authenticator = Services::OauthAuthenticator.new(facebook_data)
-      Authorization.stub(:where).and_return([authorization])
 
       authenticator.authenticate!
 
@@ -17,9 +16,7 @@ describe Services::OauthAuthenticator do
 
     it "authenticates an existing user without the given authorization" do
       facebook_data = OmniAuth.config.mock_auth[:facebook]
-      user = create :user, email: 'dummy@dummy.com'
-      User.stub(:find_by_email).and_return(user)
-      user.authorizations.stub(:create)
+      user = create :user, email: OmniAuth.config.mock_auth[:facebook].info.email
       authenticator = Services::OauthAuthenticator.new(facebook_data)
 
       authenticator.authenticate!
@@ -29,8 +26,6 @@ describe Services::OauthAuthenticator do
 
     it "creates a new user when it doesn't exist" do
       facebook_data = OmniAuth.config.mock_auth[:facebook]
-      User.any_instance.stub(:save)
-      User.any_instance.stub_chain(:authorizations, :create)
       authenticator = Services::OauthAuthenticator.new(facebook_data)
 
       authenticator.authenticate!
@@ -40,13 +35,18 @@ describe Services::OauthAuthenticator do
 
     it "sets the correct user birth_date" do
       facebook_data = OmniAuth.config.mock_auth[:facebook]
-      User.any_instance.stub(:save)
-      User.any_instance.stub_chain(:authorizations, :create)
       authenticator = Services::OauthAuthenticator.new(facebook_data)
 
       authenticator.authenticate!
 
       authenticator.user.birth_date.should eq DateTime.strptime('30/01/1990', '%d/%m/%Y')
+    end
+
+    it "doesn't fail if an optional OAuth hash is missing" do
+      facebook_data = OmniAuth.config.mock_auth[:facebook_limited]
+      authenticator = Services::OauthAuthenticator.new(facebook_data)
+
+      authenticator.authenticate!
     end
   end
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -17,4 +17,14 @@ RSpec.configure do |config|
       }
     }
   }
+
+  OmniAuth.config.add_mock :facebook_limited, {
+    provider: 'facebook',
+    uid: '1234567',
+    info: {
+      email: 'uplay@dummy.com',
+      image: 'http://dummy.url.com'
+    },
+    credentials: { token: 'dummy_token' }
+  }
 end


### PR DESCRIPTION
This fixes an error when for some this data does not come from facebook

Also simplifies some RSpec tests
