### PR TITLE
fixes tests, and makes accounts.yml uniform between deploy and dev envs

### DIFF
--- a/config/initializers/01_accounts.rb
+++ b/config/initializers/01_accounts.rb
@@ -1,9 +1,9 @@
 unless defined?(ACCOUNTS) || Rails.env.test?
   if Rails.env.production?
     file_name = '/home/deploy/config/accounts.yml'
-    ACCOUNTS = YAML.load_file(file_name)["profiles"]
   else
     file_name = "#{Rails.root}/config/accounts.yml"
-    ACCOUNTS = YAML.load_file(file_name)
   end
+
+  ACCOUNTS = YAML.load_file(file_name)["profiles"] if File.exists?(file_name)
 end


### PR DESCRIPTION
Os testes estavam a falhar em todos os branches por causa disto
E mudei também o facto de que em deploy o accounts.yml tinha o namespace `profiles` mas em development não. Acho que podia dar origem a erros ou distrações, mas comentem sff

caso passe, lembrem-se que terão que mudar o vosso accounts.yml para começar por `profiles:`
