### PR TITLE
fixes labels in experience form. also refactors I18n helpers for those labels

### DIFF
--- a/app/views/experiences/_form.slim
+++ b/app/views/experiences/_form.slim
@@ -4,24 +4,24 @@
     header = experience_presenter.title
 
     .field
-      .label: label = t('experience.form.labels.sport')
+      .label = f.label :sport
       .input.sport  = experience_presenter.exp_sport f
 
     .field
-      .label: label = t('experience.form.labels.role')
+      .label = f.label :role
       .input.role   = experience_presenter.exp_role f
 
     .field
-      .label: label = t('experience.form.labels.position')
+      .label = f.label :position
       .input.position   = experience_presenter.exp_position f
         
     .field.field--dates
-      .label: label Date
+      .label = f.label :date
       .input.start_date = experience_presenter.exp_start_date f
       .input.end_date = experience_presenter.exp_end_date f
 
     .field
-      .label: label = t('experience.form.labels.team')
+      .label = f.label :team
       .input.team   = experience_presenter.exp_team f
 
     = render 'tournaments/form', f: f, experience_presenter: experience_presenter

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,10 +27,6 @@ en:
         title: Edit Experience
       labels:
         add_more: Add more
-        sport: Sport
-        role: Role
-        postition: Position
-        team: University
       placeholders:
         achievements: Achievements
         end_date: Ongoing
@@ -98,3 +94,12 @@ en:
       title: UPlayPro
       caption: Sports stuff
       description: You know it!
+  helpers:
+    label:
+      experience:
+        sport: Sport
+        role: Role
+        position: Position
+        date: Date
+        team: University
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,9 +97,9 @@ en:
   helpers:
     label:
       experience:
-        sport: Sport
-        role: Role
-        position: Position
         date: Date
+        position: Position
+        role: Role
+        sport: Sport
         team: University
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(:version => 20131001153717) do
 
   create_table "tournaments", :force => true do |t|
     t.string   "name"
-    t.text     "achievements",  :default => "", :null => false
+    t.text     "achievements",  :default => ""
     t.date     "award_date"
     t.integer  "experience_id",                 :null => false
     t.datetime "deleted_at"


### PR DESCRIPTION
o @gabrielpoca não sabe usar labels :trollface:
isto corrige o erro que o foundation dava por causa das labels não terem o atributo `for`

aproveitei o lanço e fiz refactor ao i18n, porque os form helpers têm defaults para isso, não é preciso passar-lhes a string explicitamente
