### PR TITLE
exp form shows when there are no exps

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,7 +52,7 @@ class UsersController < ApplicationController
   def set_new_experience
     if @user == current_user
       params = flash[:new_experience_params]
-      @experience_hide = params.nil?
+      @experience_hide = @user.experiences.any? && params.nil?
       @new_experience = current_user.experiences.build(params)
       @new_experience.tournaments.build
     end


### PR DESCRIPTION
https://trello.com/c/cxhxUw6C/136-empty-state-quando-user-nao-tiver-nenhuma-equipa-apresentar-pagina-de-adicionar-equipa-em-vez-de-perfil-vazio
