### PR TITLE
tournament month is now optional

### DIFF
--- a/app/assets/stylesheets/components/_tournaments.sass
+++ b/app/assets/stylesheets/components/_tournaments.sass
@@ -19,22 +19,11 @@
 .tournament__fields
   .field--action
     width: 8%
-  .field--achievement
+  .field--achievement, .field--date
     position: relative
     width: 92%
     .input
       width: 40%
-  .field--date
-    position: relative
-    width: 92%
-    .label
-      height: 4px
-    .date
-      width: 80%
-      display: inline-block
-    .custom.dropdown
-      display: inline-block
-      width: 49.4%
   .field--tournament
     position: relative
     width: 92%

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -51,7 +51,7 @@ class ExperiencesController < ApplicationController
   def sanitize_empty_tournaments
     return if params[:experience][:tournaments_attributes].nil?
     params[:experience][:tournaments_attributes].each do |key, tournament|
-      if tournament["name"].blank? && tournament["achievements"].blank? && tournament["award_date(1i)"].blank?
+      if tournament["name"].blank? && tournament["achievements"].blank? && tournament["award_year"].blank?
         params[:experience][:tournaments_attributes].delete key
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
       params = flash[:new_experience_params]
       @experience_hide = @user.experiences.any? && params.nil?
       @new_experience = current_user.experiences.build(params)
-      @new_experience.tournaments.build
+      @new_experience.tournaments.build if @new_experience.tournaments.empty?
     end
   end
 

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -1,7 +1,7 @@
 class Tournament < ActiveRecord::Base
   include ParanoiaInterface
 
-  default_scope order: :award_date
+  default_scope order: 'award_year DESC, award_month DESC'
 
   ## Relations ##
   belongs_to :experience
@@ -14,12 +14,13 @@ class Tournament < ActiveRecord::Base
                   :icon_id,
                   :name,
                   :experience,
-                  :experience_id
+                  :experience_id,
+                  :award_year,
+                  :award_month
 
 
   ## Validations ##
   validates :name,
-            :award_date,
+            :award_year,
             presence: true
-
 end

--- a/app/presenters/experience_presenter.rb
+++ b/app/presenters/experience_presenter.rb
@@ -45,31 +45,31 @@ class ExperiencePresenter < RailsPresenter::Base
   end
 
   ########## Tournament Form helpers ##########
-  def tour_award_date(tour_form)
-    tour_form.date_select :award_date,
-                          discard_day: true,
-                          start_year: Time.now.year,
-                          end_year: 1923,
-                          order: [:month,:year],
-                          prompt: {
-                            year: h.t( 'experience.form.placeholders.year'), 
-                            month: h.t( 'experience.form.placeholders.month')
-                          }
+  def tour_award_month(form)
+    form.select :award_month,
+                h.t('date.month_names').compact.zip((1..12)),
+                include_blank: h.t('experience.form.placeholders.month')
   end
 
-  def tour_achievements(tour_form)
-    tour_form.text_field :achievements, placeholder: h.t( 'experience.form.placeholders.achievements' )
+  def tour_award_year(form)
+    form.select :award_year,
+                Time.now.year.downto(1923).to_a,
+                include_blank: h.t( 'experience.form.placeholders.year' )
   end
 
-  def tour_name(tour_form)
-    tour_form.text_field :name, placeholder: h.t( 'experience.form.placeholders.name' )
+  def tour_achievements(form)
+    form.text_field :achievements, placeholder: h.t( 'experience.form.placeholders.achievements' )
   end
 
-  def tour_icon(tour_form)
-    tour_form.collection_select :icon_id,
-                                selectable_icons,
-                                :id,
-                                :name
+  def tour_name(form)
+    form.text_field :name, placeholder: h.t( 'experience.form.placeholders.name' )
+  end
+
+  def tour_icon(form)
+    form.collection_select :icon_id,
+                           selectable_icons,
+                           :id,
+                           :name
   end
 
   def start_year

--- a/app/presenters/tournament_presenter.rb
+++ b/app/presenters/tournament_presenter.rb
@@ -11,10 +11,14 @@ class TournamentPresenter < RailsPresenter::Base
     super.try :titleize
   end
 
+  def award_month
+    target.award_month || 0
+  end
+
   def date
     h.t('tournaments.date',
-        month: h.t('date.month_names')[award_date.month],
-        year: award_date.year
+        month: h.t('date.month_names')[award_month],
+        year: award_year
        )
   end
 end

--- a/app/views/tournaments/_form.slim
+++ b/app/views/tournaments/_form.slim
@@ -13,7 +13,8 @@
       .field--action
       .field.field--date
         .label: label Date
-        .date = experience_presenter.tour_award_date tour_form
+        .input.month = experience_presenter.tour_award_month tour_form
+        .input.year = experience_presenter.tour_award_year tour_form
       .field--action
       .field.field--achievement
         .label: label Achievement

--- a/db/migrate/20131007173559_add_award_year_and_award_month_to_tournaments.rb
+++ b/db/migrate/20131007173559_add_award_year_and_award_month_to_tournaments.rb
@@ -1,0 +1,10 @@
+class AddAwardYearAndAwardMonthToTournaments < ActiveRecord::Migration
+  def change
+    add_column :tournaments, :award_year, :integer
+    add_column :tournaments, :award_month, :integer
+
+    Rake::Task['db:populate_award_year'].invoke
+
+    change_column :tournaments, :award_year, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131002131430) do
+ActiveRecord::Schema.define(:version => 20131007173559) do
 
   create_table "authorizations", :force => true do |t|
     t.integer  "user_id"
@@ -79,6 +79,8 @@ ActiveRecord::Schema.define(:version => 20131002131430) do
     t.datetime "created_at",                    :null => false
     t.datetime "updated_at",                    :null => false
     t.integer  "icon_id"
+    t.integer  "award_year",                    :null => false
+    t.integer  "award_month"
   end
 
   add_index "tournaments", ["experience_id"], :name => "index_tournaments_on_experience_id"

--- a/features/step_definitions/experience_steps.rb
+++ b/features/step_definitions/experience_steps.rb
@@ -9,7 +9,7 @@ def fill_tournament_fields
   tournament = build :tournament
   find(:css, "input[id^='experience_tournaments_attributes_'][id$='_achievements']", ).set(tournament.achievements)
   find(:css, "input[id^='experience_tournaments_attributes_'][id$='_name']").set(tournament.name)
-  find(:css, "select[id^='experience_tournaments_attributes_'][id$='_award_date_1i']").select(tournament.award_date.year)
+  find(:css, "select[id^='experience_tournaments_attributes_'][id$='_award_year']").select(tournament.award_year)
 end
 
 def submit_experience_form

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -1,0 +1,6 @@
+namespace :db do
+  desc "Populates tournament's award_year and award_month from award_date"
+  task :populate_award_year => :environment do
+    Tournament.where(award_year: nil).update_all ["award_year = strftime(?, award_date)", '%Y']
+  end
+end

--- a/spec/controllers/experiences_controller_spec.rb
+++ b/spec/controllers/experiences_controller_spec.rb
@@ -6,7 +6,7 @@ describe ExperiencesController do
     it "sanitizes empty tournaments" do
       sign_in create(:user)
       params = { experience: {
-        tournaments_attributes: {tournament1: {"name" => nil, "achievements" => nil, "award_date(1i)" => nil} }
+        tournaments_attributes: {tournament1: {"name" => nil, "achievements" => nil, "award_year" => nil} }
       } }
 
       post :create, params

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -51,6 +51,7 @@ FactoryGirl.define do
     association :icon
     sequence(:name) {|n| "#{n} WUC"}
     award_date Date.today
+    award_year Date.today.year
   end
 
   factory :tournament do
@@ -59,6 +60,7 @@ FactoryGirl.define do
     sequence(:name) {|n| "#{n} WUC"}
     achievements '1st place, MVP'
     award_date Date.today
+    award_year Date.today.year
   end
 
   factory :icon do

--- a/spec/presenters/experience_spec.rb
+++ b/spec/presenters/experience_spec.rb
@@ -6,7 +6,7 @@ describe ExperiencePresenter do
     it "returns all tournaments by order" do
       experience = build :experience
       presenter = ExperiencePresenter.new(experience, view)
-      ordered_tournaments = experience.tournaments.sort {|a,b| b.award_date <=> a.award_date }
+      ordered_tournaments = experience.tournaments.sort_by {|a| [a.award_year, a.award_month]}.reverse
 
       presenter.tournaments == ordered_tournaments
     end

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -8,7 +8,7 @@ describe UserPresenter do
       create_list(:tournament, 3, experience: experience)
 
       presenter = ExperiencePresenter.new(experience, view)
-      ordered_tournaments = experience.tournaments.sort {|a,b| b.award_date <=> a.award_date }
+      ordered_tournaments = experience.tournaments.sort_by {|a| [a.award_year, a.award_month]}.reverse
 
       presenter.tournaments == ordered_tournaments
     end


### PR DESCRIPTION
O objetivo é ter só o year do award_date obrigatório e o month opcional.
O que acontece é que quando o formulario é submetido, se o month nao tiver sido definido, o award_date date é considerado nil, ou seja nao dá para validar. Por isso decidi tratar isso no controller através de um before_filter onde adiciona o mês Janeiro ("1") ao i2 quando este nao vêm preenchido no params. Fiz desta forma porque pelos vistos não dá para usar prompts e defaults em simultaneo num date_select. http://stackoverflow.com/questions/6390221/problem-with-datetime-select-helper/6391527#6391527
